### PR TITLE
Fix low fee amount in colored coin

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1724,6 +1724,7 @@ impl Wallet {
                 &drain_script,
                 &color_id,
             )?;
+            fee_amount += coin_selection.fee_amount;
             let excess = &coin_selection.excess;
 
             tx.input.extend(
@@ -1742,10 +1743,7 @@ impl Wallet {
             match excess {
                 NoChange { .. } => {}
                 Change { amount, fee } => {
-                    // if self.is_mine(&drain_script) {
-                    //     received += Amount::from_tap(*amount);
-                    // }
-                    // fee_amount += fee;
+                    fee_amount += fee;
 
                     // create drain output
                     let drain_output = TxOut {

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -1305,7 +1305,11 @@ fn test_create_tx_with_nft() {
         .add_recipient(addr.script_pubkey(), Amount::from_tap(25_000))
         .add_recipient_with_color(addr.script_pubkey(), Amount::from_tap(1), color_id);
     let psbt = builder.finish().unwrap();
-    check_fee!(wallet, psbt);
+
+    let fee = check_fee!(wallet, psbt);
+    let feerate = FeeRate::from_tap_per_kwu(250); // 1 sat/vb
+    assert_fee_rate!(psbt, fee.unwrap_or(Amount::ZERO), feerate, @add_signature);
+
     assert_eq!(psbt.unsigned_tx.output.len(), 3);
     let sent_received = wallet.sent_and_received(
         &psbt.clone().extract_tx().expect("failed to extract tx"),
@@ -1327,8 +1331,13 @@ fn test_create_tx_with_reissuable() {
         .add_recipient(addr.script_pubkey(), Amount::from_tap(25_000))
         .add_recipient_with_color(addr.script_pubkey(), Amount::from_tap(98), color_id);
     let psbt = builder.finish().unwrap();
-    check_fee!(wallet, psbt);
+
+    let fee = check_fee!(wallet, psbt);
+    let feerate = FeeRate::from_tap_per_kwu(250); // 1 sat/vb
+    assert_fee_rate!(psbt, fee.unwrap_or(Amount::ZERO), feerate, @add_signature);
+
     assert_eq!(psbt.unsigned_tx.output.len(), 4);
+
     let sent_received = wallet.sent_and_received(
         &psbt.clone().extract_tx().expect("failed to extract tx"),
         &color_id,

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -1307,8 +1307,8 @@ fn test_create_tx_with_nft() {
     let psbt = builder.finish().unwrap();
 
     let fee = check_fee!(wallet, psbt);
-    let feerate = FeeRate::from_tap_per_kwu(250); // 1 sat/vb
-    assert_fee_rate!(psbt, fee.unwrap_or(Amount::ZERO), feerate, @add_signature);
+    let fee_rate = FeeRate::from_tap_per_kwu(250); // 1 tap/vb
+    assert_fee_rate!(psbt, fee.unwrap_or(Amount::ZERO), fee_rate, @add_signature);
 
     assert_eq!(psbt.unsigned_tx.output.len(), 3);
     let sent_received = wallet.sent_and_received(
@@ -1333,8 +1333,8 @@ fn test_create_tx_with_reissuable() {
     let psbt = builder.finish().unwrap();
 
     let fee = check_fee!(wallet, psbt);
-    let feerate = FeeRate::from_tap_per_kwu(250); // 1 sat/vb
-    assert_fee_rate!(psbt, fee.unwrap_or(Amount::ZERO), feerate, @add_signature);
+    let fee_rate = FeeRate::from_tap_per_kwu(250); // 1 tap/vb
+    assert_fee_rate!(psbt, fee.unwrap_or(Amount::ZERO), fee_rate, @add_signature);
 
     assert_eq!(psbt.unsigned_tx.output.len(), 4);
 


### PR DESCRIPTION
resolves #25
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

1. Coin Selection を colored UTXO を追加することで増える手数料（入力として追加した場合、おつりが発生した場合に追加する出力の手数料）を計算するように修正
2. colored UTXO の手数料を Transaction の手数料に参入するように修正

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
