### PR TITLE
Fix error in Colored Coin transfer transaction without TPC transfer when TPC funds are low and no change output is needed

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1821,9 +1821,7 @@ impl Wallet {
                     }
                 });
 
-                if (color_id.is_default() && outgoings.len() > 1)
-                    || (params.drain_to.is_some() && (params.drain_wallet || utxo_exists))
-                {
+                if (params.drain_to.is_some() && (params.drain_wallet || utxo_exists)) {
                     if let NoChange {
                         dust_threshold,
                         remaining_amount,
@@ -1840,6 +1838,8 @@ impl Wallet {
                             available,
                         }));
                     }
+                } else if (color_id.is_default() && outgoings.len() > 1) {
+                    // We have colored coin outputs but no TPC output
                 } else {
                     return Err(CreateTxError::NoRecipients);
                 }


### PR DESCRIPTION
TPC の送金を伴わない Colored Coin の送金用トランザクションで、TPC の資金が少なくおつりの出力が不要な場合に、エラーになる問題を修正しました。