### PR TITLE
Remove add_contract_utxo()

### DIFF
--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -464,7 +464,6 @@ impl HdWallet {
         &self,
         params: Vec<TransferParams>,
         outpoints: Vec<OutPoint>,
-        contracts: BTreeMap<String, Contract>,
         client: &BlockingClient,
     ) -> anyhow::Result<String> {
         let mut wallet = self.get_wallet();
@@ -490,7 +489,7 @@ impl HdWallet {
 
         if !outpoints.is_empty() {
             for op in outpoints.iter() {
-                tx_builder.add_contract_utxo(op.clone());
+                tx_builder.add_utxo(op.clone());
             }
         }
 
@@ -730,7 +729,6 @@ fn test_p2c_transfer() -> anyhow::Result<()> {
             to_address: another_address.clone(),
         }],
         vec![outpoint],
-        contracts.clone(),
         &client,
     );
     assert!(ret.is_ok());
@@ -761,7 +759,6 @@ fn test_colored_p2c_transfer() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_blocking();
 
     let address: String = env.tapyrusd.client.call("getnewaddress", &[]).unwrap();
-
     let address: Address = Address::from_str(&address).unwrap().assume_checked();
     let txid1 = env.tapyrusd.client.send_to_address(
         &address,
@@ -862,7 +859,6 @@ fn test_colored_p2c_transfer() -> anyhow::Result<()> {
             to_address: another_address.clone(),
         }],
         vec![outpoint],
-        contracts.clone(),
         &client,
     );
 

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2387,8 +2387,8 @@ impl Wallet {
         &self,
         utxo: &LocalOutput,
     ) -> Result<Option<Contract>, GenerateContractError> {
-        for (contract_id, contract) in self.contracts.iter() {
-            let color_id = utxo.txout.script_pubkey.color_id();
+        let color_id = utxo.txout.script_pubkey.color_id();
+        for (_, contract) in self.contracts.iter() {
             let p2c_script = self.create_pay_to_contract_script(
                 &contract.payment_base,
                 contract.contract.clone(),

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -1464,7 +1464,7 @@ fn test_create_tx_with_contract() {
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), Amount::from_tap(48_000))
-        .add_contract_utxo(OutPoint { txid, vout: 0 });
+        .add_utxo(OutPoint { txid, vout: 0 });
     let mut psbt = builder.finish().unwrap();
     check_fee!(wallet, psbt);
     assert_eq!(psbt.unsigned_tx.output.len(), 2);
@@ -1513,7 +1513,7 @@ fn test_create_tx_with_contract_unspendable() {
         let mut builder = wallet.build_tx();
         builder
             .add_recipient(addr.script_pubkey(), Amount::from_tap(48_000))
-            .add_contract_utxo(OutPoint { txid, vout: 0 });
+            .add_utxo(OutPoint { txid, vout: 0 });
 
         let mut psbt = builder.finish().unwrap();
         let finished = wallet.sign(
@@ -1545,7 +1545,7 @@ fn test_create_tx_with_contract_unspendable() {
         let mut builder = wallet.build_tx();
         builder
             .add_recipient(addr.script_pubkey(), Amount::from_tap(48_000))
-            .add_contract_utxo(OutPoint { txid, vout: 0 });
+            .add_utxo(OutPoint { txid, vout: 0 });
 
         let mut psbt = builder.finish().unwrap();
         let finished = wallet.sign(


### PR DESCRIPTION
The out points which user tries to add explicitly should be able to add tx builder even if the out points is pay to contract out point and the paynable flag is false.
